### PR TITLE
Python 3.7 Support + Small Tweaks

### DIFF
--- a/leaguepedia_parser/_tests/test.ipynb
+++ b/leaguepedia_parser/_tests/test.ipynb
@@ -64,7 +64,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 72,
    "metadata": {},
    "outputs": [
     {
@@ -73,11 +73,12 @@
       "text/plain": "{'sources': {'leaguepedia': {'scoreboardIdWiki': 'LEC/2019 Season/Summer Playoffs_Round 1_1_1',\n   'uniqueGame': 'LEC/2019 Season/Summer Playoffs/Scoreboards_1_1',\n   'match_history_url': 'http://matchhistory.na.leagueoflegends.com/en/#match-details/ESPORTSTMNT06/1040496?gameHash=985ce12baaa1bae4'},\n  'riotLolApi': {'gameId': 1040496,\n   'platformId': 'ESPORTSTMNT06',\n   'gameHash': '985ce12baaa1bae4'}},\n 'tournament': 'LEC 2019 Summer Playoffs',\n 'start': '2019-08-23T14:23:00+00:00',\n 'gameInSeries': 1,\n 'patch': '9.16',\n 'duration': 1519,\n 'vod': 'https://youtu.be/lheVyBOlbuM?t=66',\n 'winner': 'BLUE',\n 'teams': {'BLUE': {'name': 'Rogue (European Team)',\n   'players': [{'uniqueIdentifiers': {'leaguepedia': {'name': 'Finn'}},\n     'championId': 266,\n     'championName': 'Aatrox'},\n    {'uniqueIdentifiers': {'leaguepedia': {'name': 'Inspired'}},\n     'championId': 60,\n     'championName': 'Elise'},\n    {'uniqueIdentifiers': {'leaguepedia': {'name': 'Larssen'}},\n     'championId': 42,\n     'championName': 'Corki'},\n    {'uniqueIdentifiers': {'leaguepedia': {'name': 'Woolite'}},\n     'championId': 86,\n     'championName': 'Garen'},\n    {'uniqueIdentifiers': {'leaguepedia': {'name': 'Vander'}},\n     'championId': 350,\n     'championName': 'Yuumi'}],\n   'bansNames': ['Gangplank', 'Xayah', 'Shen', 'Braum', 'Gragas'],\n   'bans': [41, 498, 98, 201, 79],\n   'endOfGameStats': {'towerKills': 10,\n    'dragonKills': 3,\n    'riftHeraldKills': 1,\n    'baronKills': 1}},\n  'RED': {'name': 'Splyce',\n   'players': [{'uniqueIdentifiers': {'leaguepedia': {'name': 'Vizicsacsi'}},\n     'championId': 58,\n     'championName': 'Renekton'},\n    {'uniqueIdentifiers': {'leaguepedia': {'name': 'Xerxe'}},\n     'championId': 517,\n     'championName': 'Sylas'},\n    {'uniqueIdentifiers': {'leaguepedia': {'name': 'Humanoid'}},\n     'championId': 84,\n     'championName': 'Akali'},\n    {'uniqueIdentifiers': {'leaguepedia': {'name': 'Kobbe'}},\n     'championId': 236,\n     'championName': 'Lucian'},\n    {'uniqueIdentifiers': {'leaguepedia': {'name': 'Norskeren'}},\n     'championId': 106,\n     'championName': 'Volibear'}],\n   'bansNames': ['Olaf', 'Qiyana', 'Sejuani', 'Kled', 'Irelia'],\n   'bans': [2, 246, 113, 240, 39],\n   'endOfGameStats': {'towerKills': 1,\n    'dragonKills': 0,\n    'riftHeraldKills': 0,\n    'baronKills': 0}}}}"
      },
      "metadata": {},
-     "execution_count": 69
+     "execution_count": 72
     }
    ],
    "source": [
-    "test_game = lpp.get_games(test_tournament['name'])[0] #need to change instructions/inputs on get_games, as it currently asks for \"overviewPage\" ask game key\n",
+    "test_game = lpp.get_games(test_tournament['name'])[0] #tested after changing \"tournament_overview_page\" to \"tournamen_name\" and still works fine\n",
+    "#I didn't change functionality at all, just the variable name\n",
     "test_game"
    ]
   },

--- a/leaguepedia_parser/_tests/test.ipynb
+++ b/leaguepedia_parser/_tests/test.ipynb
@@ -1,0 +1,111 @@
+{
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": 3
+  },
+  "orig_nbformat": 2,
+  "kernelspec": {
+   "name": "python_defaultSpec_1595286133573",
+   "display_name": "Python 3.7.7 64-bit ('base': conda)"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2,
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "['', 'Africa', 'Asia', 'Brazil', 'China', 'CIS', 'Europe', 'International', 'Japan', 'Korea', 'LAN', 'LAS', 'Latin America', 'LMS', 'MENA', 'North America', 'Oceania', 'PCS', 'SEA', 'Turkey', 'Unknown', 'Vietnam', 'Wildcard']\n"
+    }
+   ],
+   "source": [
+    "import leaguepedia_parser as lpp\n",
+    "\n",
+    "test_region = lpp.get_regions()\n",
+    "print(test_region)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 66,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "{'name': 'LEC 2019 Summer Playoffs',\n 'start': '2019-08-23',\n 'end': '2019-09-08',\n 'region': 'Europe',\n 'league': 'LoL European Championship',\n 'leagueShort': 'LEC',\n 'rulebook': 'https://s3-eu-west-1.amazonaws.com/cdn.eu.lolesports.com/LEC+Rulebook+2019+(Updated+29.05.2019).pdf',\n 'tournamentLevel': 'Primary',\n 'isQualifier': True,\n 'isPlayoffs': True,\n 'isOfficial': True,\n 'overviewPage': 'LEC/2019 Season/Summer Playoffs'}"
+     },
+     "metadata": {},
+     "execution_count": 66
+    }
+   ],
+   "source": [
+    "test_tournament = lpp.get_tournaments('Europe',2019)[3]\n",
+    "test_tournament"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 69,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "{'sources': {'leaguepedia': {'scoreboardIdWiki': 'LEC/2019 Season/Summer Playoffs_Round 1_1_1',\n   'uniqueGame': 'LEC/2019 Season/Summer Playoffs/Scoreboards_1_1',\n   'match_history_url': 'http://matchhistory.na.leagueoflegends.com/en/#match-details/ESPORTSTMNT06/1040496?gameHash=985ce12baaa1bae4'},\n  'riotLolApi': {'gameId': 1040496,\n   'platformId': 'ESPORTSTMNT06',\n   'gameHash': '985ce12baaa1bae4'}},\n 'tournament': 'LEC 2019 Summer Playoffs',\n 'start': '2019-08-23T14:23:00+00:00',\n 'gameInSeries': 1,\n 'patch': '9.16',\n 'duration': 1519,\n 'vod': 'https://youtu.be/lheVyBOlbuM?t=66',\n 'winner': 'BLUE',\n 'teams': {'BLUE': {'name': 'Rogue (European Team)',\n   'players': [{'uniqueIdentifiers': {'leaguepedia': {'name': 'Finn'}},\n     'championId': 266,\n     'championName': 'Aatrox'},\n    {'uniqueIdentifiers': {'leaguepedia': {'name': 'Inspired'}},\n     'championId': 60,\n     'championName': 'Elise'},\n    {'uniqueIdentifiers': {'leaguepedia': {'name': 'Larssen'}},\n     'championId': 42,\n     'championName': 'Corki'},\n    {'uniqueIdentifiers': {'leaguepedia': {'name': 'Woolite'}},\n     'championId': 86,\n     'championName': 'Garen'},\n    {'uniqueIdentifiers': {'leaguepedia': {'name': 'Vander'}},\n     'championId': 350,\n     'championName': 'Yuumi'}],\n   'bansNames': ['Gangplank', 'Xayah', 'Shen', 'Braum', 'Gragas'],\n   'bans': [41, 498, 98, 201, 79],\n   'endOfGameStats': {'towerKills': 10,\n    'dragonKills': 3,\n    'riftHeraldKills': 1,\n    'baronKills': 1}},\n  'RED': {'name': 'Splyce',\n   'players': [{'uniqueIdentifiers': {'leaguepedia': {'name': 'Vizicsacsi'}},\n     'championId': 58,\n     'championName': 'Renekton'},\n    {'uniqueIdentifiers': {'leaguepedia': {'name': 'Xerxe'}},\n     'championId': 517,\n     'championName': 'Sylas'},\n    {'uniqueIdentifiers': {'leaguepedia': {'name': 'Humanoid'}},\n     'championId': 84,\n     'championName': 'Akali'},\n    {'uniqueIdentifiers': {'leaguepedia': {'name': 'Kobbe'}},\n     'championId': 236,\n     'championName': 'Lucian'},\n    {'uniqueIdentifiers': {'leaguepedia': {'name': 'Norskeren'}},\n     'championId': 106,\n     'championName': 'Volibear'}],\n   'bansNames': ['Olaf', 'Qiyana', 'Sejuani', 'Kled', 'Irelia'],\n   'bans': [2, 246, 113, 240, 39],\n   'endOfGameStats': {'towerKills': 1,\n    'dragonKills': 0,\n    'riftHeraldKills': 0,\n    'baronKills': 0}}}}"
+     },
+     "metadata": {},
+     "execution_count": 69
+    }
+   ],
+   "source": [
+    "test_game = lpp.get_games(test_tournament['name'])[0] #need to change instructions/inputs on get_games, as it currently asks for \"overviewPage\" ask game key\n",
+    "test_game"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 71,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "{'sources': {'leaguepedia': {'scoreboardIdWiki': 'LEC/2019 Season/Summer Playoffs_Round 1_1_1',\n   'uniqueGame': 'LEC/2019 Season/Summer Playoffs/Scoreboards_1_1',\n   'match_history_url': 'http://matchhistory.na.leagueoflegends.com/en/#match-details/ESPORTSTMNT06/1040496?gameHash=985ce12baaa1bae4'},\n  'riotLolApi': {'gameId': 1040496,\n   'platformId': 'ESPORTSTMNT06',\n   'gameHash': '985ce12baaa1bae4'}},\n 'tournament': 'LEC 2019 Summer Playoffs',\n 'start': '2019-08-23T14:23:00+00:00',\n 'gameInSeries': 1,\n 'patch': '9.16',\n 'duration': 1519,\n 'vod': 'https://youtu.be/lheVyBOlbuM?t=66',\n 'winner': 'BLUE',\n 'teams': {'BLUE': {'name': 'Rogue (European Team)',\n   'players': [{'uniqueIdentifiers': {'leaguepedia': {'name': 'Finn',\n       'irlName': 'Finn Wiestål',\n       'country': 'Sweden',\n       'birthday': '1999-06-03'}},\n     'championId': 266,\n     'championName': 'Aatrox',\n     'role': 'TOP'},\n    {'uniqueIdentifiers': {'leaguepedia': {'name': 'Inspired',\n       'irlName': 'Kacper Słoma',\n       'country': 'Poland',\n       'birthday': '2002-01-24'}},\n     'championId': 60,\n     'championName': 'Elise',\n     'role': 'JGL'},\n    {'uniqueIdentifiers': {'leaguepedia': {'name': 'Larssen',\n       'irlName': 'Emil Larsson',\n       'country': 'Sweden',\n       'birthday': '2000-03-30'}},\n     'championId': 42,\n     'championName': 'Corki',\n     'role': 'MID'},\n    {'uniqueIdentifiers': {'leaguepedia': {'name': 'Woolite',\n       'irlName': 'Paweł Pruski',\n       'country': 'Poland',\n       'birthday': ''}},\n     'championId': 86,\n     'championName': 'Garen',\n     'role': 'BOT'},\n    {'uniqueIdentifiers': {'leaguepedia': {'name': 'Vander',\n       'irlName': 'Oskar Bogdan',\n       'country': 'Poland',\n       'birthday': '1994-04-18'}},\n     'championId': 350,\n     'championName': 'Yuumi',\n     'role': 'SUP'}],\n   'bansNames': ['Gangplank', 'Xayah', 'Shen', 'Braum', 'Gragas'],\n   'bans': [41, 498, 98, 201, 79],\n   'endOfGameStats': {'towerKills': 10,\n    'dragonKills': 3,\n    'riftHeraldKills': 1,\n    'baronKills': 1}},\n  'RED': {'name': 'Splyce',\n   'players': [{'uniqueIdentifiers': {'leaguepedia': {'name': 'Vizicsacsi',\n       'irlName': 'Kiss Tamás',\n       'country': 'Hungary',\n       'birthday': '1993-06-14'}},\n     'championId': 58,\n     'championName': 'Renekton',\n     'role': 'TOP'},\n    {'uniqueIdentifiers': {'leaguepedia': {'name': 'Xerxe',\n       'irlName': 'Andrei Dragomir',\n       'country': 'Romania',\n       'birthday': '1999-11-05'}},\n     'championId': 517,\n     'championName': 'Sylas',\n     'role': 'JGL'},\n    {'uniqueIdentifiers': {'leaguepedia': {'name': 'Humanoid',\n       'irlName': 'Marek Brázda',\n       'country': 'Czech Republic',\n       'birthday': '2000-03-14'}},\n     'championId': 84,\n     'championName': 'Akali',\n     'role': 'MID'},\n    {'uniqueIdentifiers': {'leaguepedia': {'name': 'Kobbe',\n       'irlName': 'Kasper Kobberup',\n       'country': 'Denmark',\n       'birthday': '1996-09-21'}},\n     'championId': 236,\n     'championName': 'Lucian',\n     'role': 'BOT'},\n    {'uniqueIdentifiers': {'leaguepedia': {'name': 'Norskeren',\n       'irlName': 'Tore Hoel Eilertsen',\n       'country': 'Norway',\n       'birthday': '1999-12-27'}},\n     'championId': 106,\n     'championName': 'Volibear',\n     'role': 'SUP'}],\n   'bansNames': ['Olaf', 'Qiyana', 'Sejuani', 'Kled', 'Irelia'],\n   'bans': [2, 246, 113, 240, 39],\n   'endOfGameStats': {'towerKills': 1,\n    'dragonKills': 0,\n    'riftHeraldKills': 0,\n    'baronKills': 0}}},\n 'picksBans': [{'championName': 'Gangplank',\n   'championId': 41,\n   'isBan': True,\n   'team': 'BLUE'},\n  {'championName': 'Olaf', 'championId': 2, 'isBan': True, 'team': 'RED'},\n  {'championName': 'Xayah', 'championId': 498, 'isBan': True, 'team': 'BLUE'},\n  {'championName': 'Qiyana', 'championId': 246, 'isBan': True, 'team': 'RED'},\n  {'championName': 'Shen', 'championId': 98, 'isBan': True, 'team': 'BLUE'},\n  {'championName': 'Sejuani', 'championId': 113, 'isBan': True, 'team': 'RED'},\n  {'championName': 'Yuumi', 'championId': 350, 'isBan': False, 'team': 'BLUE'},\n  {'championName': 'Akali', 'championId': 84, 'isBan': False, 'team': 'RED'},\n  {'championName': 'Lucian', 'championId': 236, 'isBan': False, 'team': 'RED'},\n  {'championName': 'Garen', 'championId': 86, 'isBan': False, 'team': 'BLUE'},\n  {'championName': 'Corki', 'championId': 42, 'isBan': False, 'team': 'BLUE'},\n  {'championName': 'Renekton',\n   'championId': 58,\n   'isBan': False,\n   'team': 'RED'},\n  {'championName': 'Kled', 'championId': 240, 'isBan': True, 'team': 'RED'},\n  {'championName': 'Braum', 'championId': 201, 'isBan': True, 'team': 'BLUE'},\n  {'championName': 'Irelia', 'championId': 39, 'isBan': True, 'team': 'RED'},\n  {'championName': 'Gragas', 'championId': 79, 'isBan': True, 'team': 'BLUE'},\n  {'championName': 'Sylas', 'championId': 517, 'isBan': False, 'team': 'RED'},\n  {'championName': 'Aatrox',\n   'championId': 266,\n   'isBan': False,\n   'team': 'BLUE'},\n  {'championName': 'Elise', 'championId': 60, 'isBan': False, 'team': 'BLUE'},\n  {'championName': 'Volibear',\n   'championId': 106,\n   'isBan': False,\n   'team': 'RED'}]}"
+     },
+     "metadata": {},
+     "execution_count": 71
+    }
+   ],
+   "source": [
+    "test_get_details = lpp.get_game_details(test_game)\n",
+    "test_get_details"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ]
+}

--- a/leaguepedia_parser/transmuters/game.py
+++ b/leaguepedia_parser/transmuters/game.py
@@ -1,11 +1,14 @@
+from leaguepedia_parser.transmuters.game_players import LeaguepediaPlayerIdentifier
+from lol_dto.classes.game import LolGame, LolGameTeam, LolGamePlayer, LolGameTeamEndOfGameStats
+import lol_id_tools as lit
 import urllib.parse
 from datetime import datetime, timezone
-from typing import TypedDict
 
-import lol_id_tools as lit
-from lol_dto.classes.game import LolGame, LolGameTeam, LolGamePlayer, LolGameTeamEndOfGameStats
-
-from leaguepedia_parser.transmuters.game_players import LeaguepediaPlayerIdentifier
+import sys
+if sys.version_info >= (3, 8):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict, Literal, overload
 
 
 game_fields = {
@@ -82,20 +85,24 @@ def transmute_game(source_dict: dict) -> LolGame:
                     LolGamePlayer(
                         uniqueIdentifiers={
                             "leaguepedia": LeaguepediaPlayerIdentifier(
-                                name=source_dict[f"Team{i}Names"].split(",")[idx]
+                                name=source_dict[f"Team{i}Names"].split(",")[
+                                    idx]
                             )
                         },
-                        championId=lit.get_id(champion_name, object_type="champion"),
+                        championId=lit.get_id(
+                            champion_name, object_type="champion"),
                         championName=champion_name,
                     )
                     for idx, champion_name in enumerate(source_dict[f"Team{i}Picks"].split(","))
                 ],
                 bansNames=source_dict[f"Team{i}Bans"].split(","),
-                bans=[lit.get_id(champion) for champion in source_dict[f"Team{i}Bans"].split(",")],
+                bans=[lit.get_id(champion)
+                      for champion in source_dict[f"Team{i}Bans"].split(",")],
                 endOfGameStats=LolGameTeamEndOfGameStats(
                     towerKills=int(source_dict[f"Team{i}Towers"] or 0),
                     dragonKills=int(source_dict[f"Team{i}Dragons"] or 0),
-                    riftHeraldKills=int(source_dict[f"Team{i}RiftHeralds"] or 0),
+                    riftHeraldKills=int(
+                        source_dict[f"Team{i}RiftHeralds"] or 0),
                     baronKills=int(source_dict[f"Team{i}Barons"] or 0),
                 ),
             )
@@ -105,12 +112,14 @@ def transmute_game(source_dict: dict) -> LolGame:
 
     # For Riot API games, I directly parse the URL for the game to have its actual identifiers.
     if "leagueoflegends.com" in source_dict["MatchHistory"]:
-        parsed_url = urllib.parse.urlparse(urllib.parse.urlparse(source_dict["MatchHistory"]).fragment)
+        parsed_url = urllib.parse.urlparse(
+            urllib.parse.urlparse(source_dict["MatchHistory"]).fragment)
 
         query = urllib.parse.parse_qs(parsed_url.query)
         platform_id, game_id = parsed_url.path.split("/")[1:]
         game_hash = query["gameHash"][0]
 
-        game["sources"]["riotLolApi"] = {"gameId": int(game_id), "platformId": platform_id, "gameHash": game_hash}
+        game["sources"]["riotLolApi"] = {"gameId": int(
+            game_id), "platformId": platform_id, "gameHash": game_hash}
 
     return game

--- a/leaguepedia_parser/transmuters/game_players.py
+++ b/leaguepedia_parser/transmuters/game_players.py
@@ -15,6 +15,14 @@ game_players_fields = {
     "ScoreboardPlayers.Role_Number=gameRoleNumber",
     "ScoreboardPlayers.Champion",
     "ScoreboardPlayers.Side",
+    # ScoreboardPlayers.Deaths
+    # ScoreboardPlayers.Kills
+    # ScoreboardPlayers.Assists
+    # ScoreboardPlayers.SummonerSpells #split on " • "
+    # ScoreboardPlayers.Gold
+    # ScoreboardPlayers.CS
+    # ScoreboardPlayers.Items
+    # ScoreboardPlayers.KeystoneMastery or ScoreboardPlayers.KeystoneRune #depends on what season games were played
     "Players.Name=irlName",
     "Players.Country",
     "Players.Birthdate",
@@ -23,6 +31,7 @@ game_players_fields = {
     # "Players.Team=currentTeam",
     # "Players.Role=currentRole",
     # "Players.SoloqueueIds",
+
 }
 
 

--- a/leaguepedia_parser/transmuters/game_players.py
+++ b/leaguepedia_parser/transmuters/game_players.py
@@ -1,8 +1,13 @@
-from typing import List, TypedDict
-from lol_dto.classes.game import LolGame
-import lol_id_tools as lit
-
 from leaguepedia_parser.logger import leaguepedia_parser_logger
+import lol_id_tools as lit
+from lol_dto.classes.game import LolGame
+import sys
+if sys.version_info >= (3, 8):
+    from typing import TypedDict
+else:
+    from typing import List
+    from typing_extensions import TypedDict, Literal, overload
+
 
 # TODO Add more fields?
 game_players_fields = {

--- a/leaguepedia_parser/transmuters/tournament.py
+++ b/leaguepedia_parser/transmuters/tournament.py
@@ -1,5 +1,8 @@
-from typing import TypedDict
-
+import sys
+if sys.version_info >= (3, 8):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict, Literal, overload
 
 # Leaguepedia name
 tournaments_fields = {


### PR DESCRIPTION
### @mrtolkien Changes/Rationale below:

`leaguepedia_parser/_tests/test.ipynb`
- Added a python notebook for iterative testing... Maybe not useful to you, but helpful for quick tests and verification

`leaguepedia_parser/parsers/game_parser.py`
- Changed the help info for leaguepedia_parser.get_players() so that it reflects the correct field, "name", required for query to succeed 
_(My VS Studio is stupid about formatting and won't let me save without it fiddling with it, so pay the spacing changes no mind)_

`leaguepedia_parser/transmuters/game.py`
- Added a quick version check that'll allow people running versions of Python older than 3.8 to use this as well by using typing_extentions
- I'll be adding this these changes to lol-dto as well if this is approved, so be on the lookout for that

`leaguepedia_parser/transmuters/game_players.py` and `leaguepedia_parser/transmuters/tournament.py`
- "Added a quick version check..." (see above)

