### PR TITLE
implement comparable queries and more queryable fields for get_games()

### DIFF
--- a/leaguepedia_parser/__init__.py
+++ b/leaguepedia_parser/__init__.py
@@ -1,2 +1,3 @@
 from leaguepedia_parser.parsers.game_parser import get_regions, get_tournaments, get_games, get_game_details
 from leaguepedia_parser.parsers.team_parser import get_team_logo, get_long_team_name
+import leaguepedia_parser.parsers.compare as compare

--- a/leaguepedia_parser/parsers/compare.py
+++ b/leaguepedia_parser/parsers/compare.py
@@ -1,0 +1,27 @@
+import functools
+
+def __common_out(operator, operand):
+    def apply(operator, operand, base_operand):
+        return f"{base_operand} {operator} '{operand}'"
+
+    return functools.partial(apply, operator, operand)
+
+def less_than(operand):
+    return __common_out(">", operand)
+
+def less_equal_to(operand):
+    return __common_out(">=", operand)
+
+def greater_than(operand):
+    return __common_out("<", operand)
+
+def greater_equal_to(operand):
+    return __common_out("<=", operand)
+
+def equal_to(operand):
+    return __common_out("=", operand)
+
+def between(operand_1, operand_2):
+    def apply(operand_1, operand_2, base_operand):
+        return f"{base_operand} > '{operand_1}' AND {base_operand} < '{operand_2}'"
+    return functools.partial(apply, operand_1, operand_2)

--- a/leaguepedia_parser/parsers/game_parser.py
+++ b/leaguepedia_parser/parsers/game_parser.py
@@ -70,7 +70,7 @@ def get_tournaments(
     return [transmute_tournament(tournament) for tournament in result]
 
 
-def get_games(tournament_overview_page=None, **kwargs) -> List[LolGame]:
+def get_games(tournament_overview_page=None, datetime=None, patch=None, **kwargs) -> List[LolGame]:
     """Returns the list of games played in a tournament.
 
     Returns basic information about all games played in a tournament.
@@ -116,10 +116,28 @@ def get_games(tournament_overview_page=None, **kwargs) -> List[LolGame]:
         "UniqueGame",
     }
 
+    def build_args(conditions):
+        args = []
+        for (key, result) in conditions:
+            if key:
+                args.append(result)
+
+        return " AND ".join(args)
+
+    def build_input(key, fun):
+        if not fun: return (None, None)
+        return (fun, fun(f"ScoreboardGames.{key}"))
+    
+    args = build_args([
+        (build_input("OverviewPage", tournament_overview_page)),
+        (build_input("DateTime_UTC", datetime)),
+        (build_input("Patch", patch)),
+    ])
+
     games = leaguepedia.query(
         tables="ScoreboardGames",
         fields=", ".join(game_fields),
-        where=f"ScoreboardGames.OverviewPage ='{tournament_overview_page}'",
+        where=args,
         order_by="ScoreboardGames.DateTime_UTC",
         **kwargs,
     )


### PR DESCRIPTION
This pull request provides some new features to `get_games()`:
* Add support for other query fields.
* Implement compare interface for query (i.e. search for date greater than x)

I will generate test cases and documentation if you accept the paradigm shift which this implementation brings.

Example use cases:
```python
games = leaguepedia_parser.get_games(
    patch=leaguepedia_parser.compare.equal_to("8.14")
)

games = leaguepedia_parser.get_games(
    patch=leaguepedia_parser.compare.between("2019-04-03", "2020-05-06")
)
```