### PR TITLE
Fix demo gif link for PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ more than welcome!
 `pip install leaguepedia_parser`
 
 # Demo
-![Demo](leaguepedia_parser_demo.gif)
+![Demo](https://raw.githubusercontent.com/mrtolkien/leaguepedia_parser/master/leaguepedia_parser_demo.gif)
 
 # Usage
 ```python


### PR DESCRIPTION
Changed the demo gif link from the Readme because it was broken on PyPI