### PR TITLE
Set game.sources.riotLolApi for new Riot/Bayes games

### DIFF
--- a/leaguepedia_parser/transmuters/field_names.py
+++ b/leaguepedia_parser/transmuters/field_names.py
@@ -45,6 +45,7 @@ game_fields = {
     "Team2Inhibitors",
     "Patch",
     "MatchHistory",
+    "RiotPlatformGameId",
     "VOD",
     "Gamename",
     "N_GameInMatch",

--- a/leaguepedia_parser/transmuters/game.py
+++ b/leaguepedia_parser/transmuters/game.py
@@ -110,5 +110,14 @@ def transmute_game(source_dict: dict) -> LolGame:
             "riotLolApi",
             RiotGameSource(gameId=game_id, platformId=platform_id, gameHash=game_hash),
         )
+    # For new tournaments, where the ID is directly input in the wiki instead of the match history URL.
+    elif not source_dict.get("MatchHistory") and source_dict.get("RiotPlatformGameId"):
+        platform_id, game_id = source_dict["RiotPlatformGameId"].split("_")
+
+        setattr(
+            game.sources,
+            "riotLolApi",
+            RiotGameSource(gameId=game_id, platformId=platform_id),
+        )
 
     return game

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "leaguepedia_parser"
-version = "2.0.1"
+version = "2.0.2"
 description = "A parser for Leaguepedia data"
 authors = ["Tolki <gary.mialaret@gmail.com>"]
 license = "MIT"

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -10,6 +10,7 @@ tournaments_names = [
     "LCK/2021 Season/Spring Season",
     "LPL/2020 Season/Spring Season",
     "LPL/2021 Season/Spring Season",
+    "2023 Mid-Season Invitational"
 ]
 
 


### PR DESCRIPTION
New games from the Riot/Bayes API don't have match history urls, so we get the RiotPlatformGameId from Leaguepedia, which is directly input by editors, and use it to set `game.sources.riotLolApi` for our game.

I also added MSI 2023 to the list of tournaments to test, which has games from bayes.