### PR TITLE
feat: add get game data and timeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ game = leaguepedia_parser.get_game_details(games[0])
 
 # Gets the URL of the team’s logo
 logo_url = leaguepedia_parser.get_team_logo('T1')
+
+# Get end-of-game and timeline JSON data
+data, timeline = leaguepedia.get_game_data_and_timeline(game)
 ```
 
 More usage examples can be found in the [`tests` folder](https://github.com/mrtolkien/leaguepedia_parser/tree/master/tests).

--- a/leaguepedia_parser/__init__.py
+++ b/leaguepedia_parser/__init__.py
@@ -3,6 +3,7 @@ from leaguepedia_parser.parsers.game_parser import (
     get_tournaments,
     get_games,
     get_game_details,
+    get_game_data_and_timeline
 )
 from leaguepedia_parser.parsers.team_parser import (
     get_team_logo,

--- a/leaguepedia_parser/parsers/game_parser.py
+++ b/leaguepedia_parser/parsers/game_parser.py
@@ -1,5 +1,5 @@
 from concurrent.futures.thread import ThreadPoolExecutor
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from lol_dto.classes.game import LolGame
 from lol_dto.classes.game.lol_game import LolPickBan
@@ -136,6 +136,26 @@ def get_game_details(game: LolGame, add_page_id=False) -> LolGame:
     game.picksBans = picks_bans_future.result()
 
     return game
+
+
+def get_game_data_and_timeline(game: LolGame) -> Tuple[Optional[dict], Optional[dict]]:
+    """Returns end-of-game and timeline JSON data from Leaguepedia if it exists.
+
+    Example of data format: 
+        timeline data - https://lol.fandom.com/wiki/V4_data:BR1_1926164473/Timeline
+        end-of-game data - https://lol.fandom.com/wiki/V4_data:BR1_1926164473
+
+    You can use riot_transmute to convert the dicts into a single LolGame dataclass:
+        import riot_transmute
+        game_data, game_timeline = leaguepedia.get_game_data_and_timeline(lol_game)
+        game = riot_transmute.match_to_game(game_data, match_v5=match_v5)
+        timeline = riot_transmute.match_timeline_to_game(game_timeline, game_id, platform_id, match_v5=match_v5)
+        merged_game = riot_transmute.merge_games_from_riot_match_and_timeline(game, timeline)
+    """
+    if hasattr(game, 'sources') and hasattr(game.sources, 'riotLolApi'):
+        game_id = game.sources.riotLolApi.platformId + "_" + game.sources.riotLolApi.gameId
+        return leaguepedia.get_game_json(game_id)
+    return None, None
 
 
 def _get_picks_bans(game: LolGame) -> Optional[List[LolPickBan]]:

--- a/leaguepedia_parser/site/leaguepedia.py
+++ b/leaguepedia_parser/site/leaguepedia.py
@@ -50,6 +50,23 @@ class LeaguepediaSite:
                 break
 
         return result
+    
+    def get_game_json(self, riot_platform_game_id: str):
+        """Gets end-of-game and timeline JSON data for given game.
+        
+        Params:
+            riot_platform_game_id: PlatformId + "_" + GameId
+        
+        Returns:
+            tuple containing 2 dicts: end-of-game data, timeline data
+        """
+        try:
+            data, timeline = self._site.get_data_and_timeline(riot_platform_game_id,
+                                                              version=5)  # try to get V5 data, returns two values, the data and timeline json
+        except KeyError:
+            data, timeline = self._site.get_data_and_timeline(riot_platform_game_id,
+                                                              version=4)  # if it fails try getting V4 data
+        return data, timeline
 
 
 # Ghost loaded instance shared by all other classes


### PR DESCRIPTION
* Add support for getting v4 and v5 PostGame data and timeline JSONs from leaguepedia

### TO DO
* Add riot_transmute to dependencies
* Use riot_transmute to merge the data and timeline into a single LolGame
* Merge leagupedia_parser's LolGame with riot_transmute's merged LolGame to create a single LolGame instance with leagupedia source/metadata as well as timeline frame data